### PR TITLE
Added vnet name as parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "network" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  name                = "acctvnet"  
+  name                = "${var.vnet_name}"  
   location            = "${var.location}"
   address_space       = ["${var.address_space}"]
   resource_group_name = "${azurerm_resource_group.network.name}"

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "azurerm_subnet" "subnet" {
 }
 
 resource "azurerm_network_security_group" "security_group" {
-  name                  = "acctsecgrp" 
+  name                  = "${var.sg_name}" 
   location              = "${var.location}"
   resource_group_name   = "${azurerm_resource_group.network.name}"
   tags                  = "${var.tags}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "vnet_name" {
+  description = "Name of the vnet to create"
+  default = "acctvnet"
+}
+
 variable "resource_group_name" {
   description = "Default resource group name that the network will be created in."
   default = "myapp-rg"

--- a/variables.tf
+++ b/variables.tf
@@ -51,3 +51,9 @@ variable "allow_ssh_traffic" {
   description = "This optional variable, when set to true, adds a security rule allowing SSH traffic to flow through to the newly created network. The default value is false."
   default = false  
 }
+
+
+variable "sg_name" {
+  description = "Give a name to security group"
+  default = "acctsecgrp"
+}


### PR DESCRIPTION
Adding the ability to name a vnet with parameter.

```
module "network" { 
    source              = "Azure/network/azurerm"
    vnet_name                = "MyVnetName"
    ...

```