### PR TITLE
remove undefined dns_servers output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -18,11 +18,6 @@ output "vnet_address_space" {
   value = "${azurerm_virtual_network.vnet.address_space}"
 }
 
-output "vnet_dns_servers" {
-  description = "The DNS servers of the newly created vNet"  
-  value = "${azurerm_virtual_network.vnet.dns_servers}"
-}
-
 output "vnet_subnets" {
   description = "The ids of subnets created inside the newl vNet"    
   value = "${azurerm_subnet.subnet.*.id}"


### PR DESCRIPTION
As per the docs, the dns_servers attribute does not exist in the azurerm_virtual_network resource: https://www.terraform.io/docs/providers/azurerm/r/virtual_network.html#attributes-reference and as such needs to be removed as otherwise it will result in an error when using terraform >= 0.11.0