### PR TITLE
Use terramodtest package to run test kitchen tasks.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,7 +11,7 @@ provisioner:
 
 platforms:
   -
-    name: "ubuntu"
+    name: "network"
 
 verifier:
   name: "terraform"
@@ -22,4 +22,4 @@ verifier:
         - "state_file"
 
 suites:
-  - name: "network"
+  - name: "default"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ jobs:
     - stage: rake full
       install: true
       script:
-      - docker build -t ${IMAGE_NAME} .
+      - docker build --build-arg BUILD_TERRAFORM_VERSION=${TERRAFORM_VERSION} -t ${IMAGE_NAME} .
       - docker run ${IMAGE_NAME} rake full

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
 
 jobs:
   include:
-    - stage: rake build
+    - stage: rake full
       install: true
       script:
       - docker build -t ${IMAGE_NAME} .
-      - docker run ${IMAGE_NAME} rake build
+      - docker run ${IMAGE_NAME} rake full

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM microsoft/terraform-test:0.11.1
+# Pull the base image with given version.
+ARG BUILD_TERRAFORM_VERSION="0.11.1"
+FROM microsoft/terraform-test:${BUILD_TERRAFORM_VERSION}
 
 ARG MODULE_NAME="terraform-azurerm-network"
+
+# Declare default build configurations for terraform.
 ARG BUILD_ARM_SUBSCRIPTION_ID=""
 ARG BUILD_ARM_CLIENT_ID=""
 ARG BUILD_ARM_CLIENT_SECRET=""
@@ -8,6 +12,7 @@ ARG BUILD_ARM_TENANT_ID=""
 ARG BUILD_ARM_TEST_LOCATION="WestEurope"
 ARG BUILD_ARM_TEST_LOCATION_ALT="WestUS"
 
+# Set environment variables for terraform runtime.
 ENV ARM_SUBSCRIPTION_ID=${BUILD_ARM_SUBSCRIPTION_ID}
 ENV ARM_CLIENT_ID=${BUILD_ARM_CLIENT_ID}
 ENV ARM_CLIENT_SECRET=${BUILD_ARM_CLIENT_SECRET}

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org/'
 
 group :test do
   git 'https://github.com/Azure/terramodtest.git' do
-    gem 'terramodtest', :tag => 'v0.1.0'
+    gem 'terramodtest', :tag => 'v0.2.0'
   end
   gem 'test-kitchen', '1.16.0'
   gem 'kitchen-terraform', '3.0.0'

--- a/README.md
+++ b/README.md
@@ -123,13 +123,13 @@ $ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --buil
 This runs the build and unit tests:
 
 ```sh
-$ docker run --rm azure-network /bin/bash -c "rake build"
+$ docker run --rm azure-network /bin/bash -c "bundle install && rake build"
 ```
 
 This runs the end to end tests:
 
 ```sh
-$ docker run -v ~/.ssh:/root/.ssh/ --rm azure-network /bin/bash -c "rake e2e"
+$ docker run -v ~/.ssh:/root/.ssh/ --rm azure-network /bin/bash -c "bundle install && rake e2e"
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,29 +26,17 @@ namespace :static do
 end
 
 namespace :integration do
-  task :converge do 
-    exit_code = `kitchen converge`
-    if exit_code != 0
-      raise "ERROR: Test kitchen converge failed! #{exit_code}\n"
-    end
+  task :converge do
+    kitchen_converge
   end
   task :verify do
-    exit_code = `kitchen verify`
-    if exit_code != 0
-      raise "ERROR: Test kitchen verify failed! #{exit_code}\n"
-    end
+    kitchen_verify
   end
   task :test do
-    exit_code = `kitchen test`
-    if exit_code != 0
-      raise "ERROR: Test kitchen test failed! #{exit_code}\n"
-    end
+    kitchen_test
   end
   task :destroy do
-    exit_code = `kitchen destroy`
-    if exit_code != 0
-      raise "ERROR: Test kitchen destroy failed! #{exit_code}\n"
-    end
+    kitchen_destroy
   end
 end
 

--- a/test/integration/default/controls/state_file_spec.rb
+++ b/test/integration/default/controls/state_file_spec.rb
@@ -8,11 +8,16 @@ control "state_file" do
   # Define how critical this control is.
   impact 0.6
   # The actual test case.
-  describe "the Terraform state file" do
+  describe file("terraform.tfstate.d/kitchen-terraform-default-network/terraform.tfstate") do
+
+    file = File.read("terraform.tfstate.d/kitchen-terraform-default-network/terraform.tfstate")
     # Get json object of terraform state file.
-    subject do json(terraform_state).terraform_version end
+    data_hash = JSON.parse(file)
+    modules = data_hash["modules"]
+
+    subject do modules[1]["resources"]["azurerm_virtual_network.vnet"]["type"] end
 
     # Validate the terraform version number field.
-    it "is accessible" do is_expected.to match /\d+\.\d+\.\d+/ end
+    it "is valid" do is_expected.to match "azurerm_virtual_network" end
   end
 end

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,3 @@
 ---
-name: network
+name: default
 version: 0.1.0


### PR DESCRIPTION
This PR contains:
1. Upgrade terramodtest v0.2.0 to get test-kitchen tasks support.
2. Replace test-kitchen code in Rakefile with reusable task from gem package.
3. Update Readme to contain "bundle install" before run "rake" build task.