### PR TITLE
Add a lifecycle block to the subnet resource to ignore network_security_group_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,4 +19,8 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name  = "${azurerm_resource_group.network.name}"
   address_prefix       = "${var.subnet_prefixes[count.index]}"
   count                = "${length(var.subnet_names)}"
+
+  lifecycle = {
+    ignore_changes = ["network_security_group_id"]
+  }
 }


### PR DESCRIPTION
This PR addresses the issue of removing security group assignments between each terraform plan. It seems that the `network_security_group_id` by default is empty. On init run everything seems to work as normal but when you issue the next terraform plan it will remove any security group assignments. This lifecycle block will ignore this attribute allowing a correct plan to be generated. 

#23 