### PR TITLE
Major update - change subnets from list to map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ terraform.tfvars
 # Compiled files
 *.tfstate
 *.tfstate.backup
+tfplan
 
 # Terraform directory
 .terraform/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.31.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_tflint
+      args: ['args=--deep']
+    - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ This runs the full tests:
 $ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
 ```
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Authors
 
 Originally created by [Eugene Chuvyrov](http://github.com/echuvyrov)

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ $ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
 ## Authors
 
 Originally created by [Eugene Chuvyrov](http://github.com/echuvyrov)
+Updated by [Alex Bevan](http://github.com/Alex Bevan)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
 ## Authors
 
 Originally created by [Eugene Chuvyrov](http://github.com/echuvyrov)
-Updated by [Alex Bevan](http://github.com/Alex Bevan)
+Updated by [Alex Bevan](http://github.com/echuvyrov)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 [![Build Status](https://travis-ci.org/Azure/terraform-azurerm-network.svg?branch=master)](https://travis-ci.org/Azure/terraform-azurerm-network)
 
-## Create a basic network in Azure
+## Create a basic network in Azure, optionally create subnets and NSG attached to those subnets
 
-This Terraform module deploys a Virtual Network in Azure with a subnet or a set of subnets passed in as input parameters.
+This Terraform module deploys a Virtual Network in Azure with a subnet and NSG or a set of subnets passed in as input parameters.
 
-The module does not create nor expose a security group. You could use https://github.com/Azure/terraform-azurerm-vnet to assign network security group to the subnets.
 
-## Usage
+## Usage - create vnet two subnets with associated nsgs
 ```hcl
 resource "azurerm_resource_group" "test" {
   name     = "my-resources"
@@ -19,8 +18,36 @@ module "network" {
   source              = "Azure/network/azurerm"
   resource_group_name = azurerm_resource_group.test.name
   address_space       = "10.0.0.0/16"
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+
+  subnets = {
+    subnet1 = {
+      address_prefixes = ["10.0.1.0/24"]
+    }
+    subnet2 = {
+      address_prefixes = ["10.0.2.0/24"]
+    }
+  }
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
+}
+
+```
+
+## Usage - create vnet with no subnsets
+```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "my-resources"
+  location = "West Europe"
+}
+
+module "network" {
+  source              = "Azure/network/azurerm"
+  resource_group_name = azurerm_resource_group.test.name
+  address_space       = "10.0.0.0/16"
+  subnets = {}
 
   tags = {
     environment = "dev"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This Terraform module deploys a Virtual Network in Azure with a subnet and NSG or a set of subnets passed in as input parameters.
 
 
-## Usage - create vnet two subnets with associated nsgs
+## Usage - create vnet two subnets, subnet1 without NSG subnet2 with NSG
 ```hcl
 resource "azurerm_resource_group" "test" {
   name     = "my-resources"
@@ -22,6 +22,7 @@ module "network" {
   subnets = {
     subnet1 = {
       address_prefixes = ["10.0.1.0/24"]
+      nsg              = false
     }
     subnet2 = {
       address_prefixes = ["10.0.2.0/24"]

--- a/README.md
+++ b/README.md
@@ -129,6 +129,38 @@ $ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| azurerm | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| address\_space | The address space that is used by the virtual network. | `list(string)` | <pre>[<br>  "10.0.0.0/16"<br>]</pre> | no |
+| dns\_servers | The DNS servers to be used with vNet. | `list` | `[]` | no |
+| name | Name of the vnet to create | `string` | `"acctvnet"` | no |
+| resource\_group\_name | Name of the resource group to be imported. | `any` | n/a | yes |
+| subnets | If no values specified, this defaults to creating two subnets | `map` | <pre>{<br>  "subnet1": {<br>    "address_prefixes": [<br>      "10.0.2.0/24"<br>    ]<br>  }<br>}</pre> | no |
+| tags | The tags to associate with your network and subnets. | `map(string)` | <pre>{<br>  "env": "test"<br>}</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| network\_security\_groups | The network security groups objects created by this module |
+| subnets | The subnets created by this module |
+| vnet | The entire azurerm\_virtual\_network resource |
+| vnet\_address\_space | The address space of the newly created vNet |
+| vnet\_id | The id of the newly created vNet |
+| vnet\_location | The location of the newly created vNet |
+| vnet\_name | The Name of the newly created vNet |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_subnet" "this" {
 }
 
 resource "azurerm_network_security_group" "this" {
-  for_each            = var.subnets
+  for_each            = var.create_nsgs ? var.subnets : {}
   name                = each.key
   location            = data.azurerm_resource_group.this.location
   resource_group_name = data.azurerm_resource_group.this.name
@@ -28,8 +28,7 @@ resource "azurerm_network_security_group" "this" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "vnet" {
-  for_each                  = var.subnets
+  for_each                  = var.create_nsgs ? var.subnets : {}
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.key].id
 }
-

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,28 @@ resource "azurerm_network_security_group" "this" {
   location            = data.azurerm_resource_group.this.location
   resource_group_name = data.azurerm_resource_group.this.name
   tags                = var.tags
+
+
+  dynamic "security_rule" {
+    for_each = lookup(each.value, "nsg_rules", [])
+    content {
+      name                                       = lookup(security_rule.value, "name", null)
+      priority                                   = lookup(security_rule.value, "priority", null)
+      direction                                  = lookup(security_rule.value, "direction", null)
+      access                                     = lookup(security_rule.value, "access", null)
+      protocol                                   = lookup(security_rule.value, "protocol", null)
+      source_port_range                          = lookup(security_rule.value, "source_port_range", null)
+      source_port_ranges                         = lookup(security_rule.value, "source_port_ranges", null)
+      destination_port_range                     = lookup(security_rule.value, "destination_port_range", null)
+      destination_port_ranges                    = lookup(security_rule.value, "destination_port_ranges", null)
+      source_address_prefix                      = lookup(security_rule.value, "source_address_prefix", null)
+      source_address_prefixes                    = lookup(security_rule.value, "source_address_prefixes", null)
+      destination_address_prefix                 = lookup(security_rule.value, "destination_address_prefix", null)
+      destination_address_prefixes               = lookup(security_rule.value, "destination_address_prefixes", null)
+      source_application_security_group_ids      = lookup(security_rule.value, "source_application_security_group_ids", null)
+      destination_application_security_group_ids = lookup(security_rule.value, "destination_application_security_group_ids", null)
+    }
+  }
 }
 
 resource "azurerm_subnet_network_security_group_association" "vnet" {
@@ -39,5 +61,3 @@ resource "azurerm_subnet_network_security_group_association" "vnet" {
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.key].id
 }
-
-

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,11 @@ resource "azurerm_subnet" "this" {
 }
 
 resource "azurerm_network_security_group" "this" {
-  for_each            = var.create_nsgs ? var.subnets : {}
+  for_each = {
+    for k, r in var.subnets : k => r
+    if lookup(r, "nsg", true)
+  }
+
   name                = each.key
   location            = data.azurerm_resource_group.this.location
   resource_group_name = data.azurerm_resource_group.this.name
@@ -28,7 +32,12 @@ resource "azurerm_network_security_group" "this" {
 }
 
 resource "azurerm_subnet_network_security_group_association" "vnet" {
-  for_each                  = var.create_nsgs ? var.subnets : {}
+  for_each = {
+    for k, r in var.subnets : k => r
+    if lookup(r, "nsg", true)
+  }
   subnet_id                 = azurerm_subnet.this[each.key].id
   network_security_group_id = azurerm_network_security_group.this[each.key].id
 }
+
+

--- a/main.tf
+++ b/main.tf
@@ -1,21 +1,35 @@
-#Azure Generic vNet Module
-data "azurerm_resource_group" "network" {
+data azurerm_resource_group "this" {
   name = var.resource_group_name
 }
 
-resource "azurerm_virtual_network" "vnet" {
-  name                = var.vnet_name
-  resource_group_name = data.azurerm_resource_group.network.name
-  location            = data.azurerm_resource_group.network.location
-  address_space       = [var.address_space]
+resource azurerm_virtual_network "this" {
+  name                = var.name
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+  address_space       = var.address_space
   dns_servers         = var.dns_servers
   tags                = var.tags
 }
 
-resource "azurerm_subnet" "subnet" {
-  count                = length(var.subnet_names)
-  name                 = var.subnet_names[count.index]
-  resource_group_name  = data.azurerm_resource_group.network.name
-  address_prefixes     = [var.subnet_prefixes[count.index]]
-  virtual_network_name = azurerm_virtual_network.vnet.name
+resource "azurerm_subnet" "this" {
+  for_each             = var.subnets
+  name                 = each.key
+  resource_group_name  = data.azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = lookup(var.subnets[each.key], "address_prefixes")
 }
+
+resource "azurerm_network_security_group" "this" {
+  for_each            = var.subnets
+  name                = each.key
+  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.this.name
+  tags                = var.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "vnet" {
+  for_each                  = var.subnets
+  subnet_id                 = azurerm_subnet.this[each.key].id
+  network_security_group_id = azurerm_network_security_group.this[each.key].id
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,33 @@
+output "vnet" {
+  description = "The entire azurerm_virtual_network resource"
+  value       = azurerm_virtual_network.this
+}
 output "vnet_id" {
   description = "The id of the newly created vNet"
-  value       = azurerm_virtual_network.vnet.id
+  value       = azurerm_virtual_network.this.id
 }
 
 output "vnet_name" {
   description = "The Name of the newly created vNet"
-  value       = azurerm_virtual_network.vnet.name
+  value       = azurerm_virtual_network.this.name
 }
 
 output "vnet_location" {
   description = "The location of the newly created vNet"
-  value       = azurerm_virtual_network.vnet.location
+  value       = azurerm_virtual_network.this.location
 }
 
 output "vnet_address_space" {
   description = "The address space of the newly created vNet"
-  value       = azurerm_virtual_network.vnet.address_space
+  value       = azurerm_virtual_network.this.address_space
 }
 
-output "vnet_subnets" {
-  description = "The ids of subnets created inside the newl vNet"
-  value       = azurerm_subnet.subnet.*.id
+output "subnets" {
+  description = "The subnets created by this module"
+  value       = azurerm_subnet.this
+}
+
+output "network_security_groups" {
+  description = "The network security groups objects created by this module"
+  value       = azurerm_network_security_group.this
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -7,17 +7,40 @@ resource "random_id" "rg_name" {
 }
 
 resource "azurerm_resource_group" "test" {
-  name     = "testRG-${random_id.rg_name.hex}"
+  name     = "test-${random_id.rg_name.hex}-rg"
   location = var.location
 }
 
-module "network" {
+
+module "vnet" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
-  address_space       = "10.0.0.0/16"
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
+  name                = "vnet"
+  address_space       = ["10.0.0.0/16"]
 
+  subnets = {
+    subnet1 = {
+      address_prefixes = ["10.0.1.0/24"]
+    }
+    subnet2 = {
+      address_prefixes = ["10.0.2.0/24"]
+    }
+  }
+
+  tags = {
+    environment = "dev"
+    costcenter  = "it"
+  }
+}
+
+// example with no subnets
+
+module "vnet2" {
+  source              = "../../"
+  resource_group_name = azurerm_resource_group.test.name
+  name                = "vnet2"
+  address_space       = ["10.0.0.0/16"]
+  subnets             = {}
   tags = {
     environment = "dev"
     costcenter  = "it"

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -8,7 +8,7 @@ resource "random_id" "rg_name" {
 
 resource "azurerm_resource_group" "test" {
   name     = "test-${random_id.rg_name.hex}-rg"
-  location = var.location
+  location = "UK South"
 }
 
 
@@ -20,6 +20,30 @@ module "vnet" {
   subnets = {
     subnet1 = {
       address_prefixes = ["10.0.1.0/24"]
+      nsg_rules = [
+        {
+          name                       = "W32Time",
+          priority                   = "100"
+          direction                  = "Inbound"
+          access                     = "Allow"
+          protocol                   = "UDP"
+          source_port_range          = "*"
+          destination_port_range     = "123"
+          source_address_prefix      = "*"
+          destination_address_prefix = "*"
+        },
+        {
+          name                       = "RPC-Endpoint-Mapper",
+          priority                   = "101"
+          direction                  = "Inbound"
+          access                     = "Allow"
+          protocol                   = "UDP"
+          source_port_range          = "*"
+          destination_port_range     = "135"
+          source_address_prefix      = "*"
+          destination_address_prefix = "*"
+        }
+      ]
     }
     subnet2 = {
       address_prefixes = ["10.0.2.0/24"]

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -17,7 +17,6 @@ module "vnet" {
   resource_group_name = azurerm_resource_group.test.name
   name                = "vnet"
   address_space       = ["10.0.0.0/16"]
-
   subnets = {
     subnet1 = {
       address_prefixes = ["10.0.1.0/24"]
@@ -46,3 +45,4 @@ module "vnet2" {
     costcenter  = "it"
   }
 }
+

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -23,6 +23,7 @@ module "vnet" {
     }
     subnet2 = {
       address_prefixes = ["10.0.2.0/24"]
+      nsg              = false
     }
   }
 

--- a/test/fixture/outputs.tf
+++ b/test/fixture/outputs.tf
@@ -1,3 +1,11 @@
 output "test_vnet_id" {
-  value = "${module.network.vnet_id}"
+  value = module.vnet.vnet_id
+}
+
+output "vnet_subnets" {
+  value = module.vnet.subnets
+}
+
+output "vnet_subnet1_id" {
+  value = module.vnet.subnets["subnet1"].id
 }

--- a/test/fixture/terraform.tfvars
+++ b/test/fixture/terraform.tfvars
@@ -1,1 +1,0 @@
-location = "westus"

--- a/test/fixture/variables.tf
+++ b/test/fixture/variables.tf
@@ -1,1 +1,0 @@
-variable "location" {}

--- a/variables.tf
+++ b/variables.tf
@@ -32,12 +32,6 @@ variable "subnets" {
   }
 }
 
-variable "create_nsgs" {
-  type = bool
-  description = "(optional) Should this module create a NSG for each subnet"
-  default = true
-}
-
 variable "tags" {
   description = "The tags to associate with your network and subnets."
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,6 @@ variable "tags" {
   type        = map(string)
 
   default = {
-    ENV = "test"
+    env = "test"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,16 @@
-variable "vnet_name" {
+variable "name" {
   description = "Name of the vnet to create"
   default     = "acctvnet"
 }
 
 variable "resource_group_name" {
-  description = "The name of an existing resource group to be imported."
+  description = "Name of the resource group to be imported."
 }
 
 variable "address_space" {
+  type        = list(string)
   description = "The address space that is used by the virtual network."
-  default     = "10.0.0.0/16"
+  default     = ["10.0.0.0/16"]
 }
 
 # If no values specified, this defaults to Azure DNS 
@@ -18,14 +19,17 @@ variable "dns_servers" {
   default     = []
 }
 
-variable "subnet_prefixes" {
-  description = "The address prefix to use for the subnet."
-  default     = ["10.0.1.0/24"]
-}
+# If no values specified, this defaults to creating two subnets
+variable "subnets" {
+  default = {
+    subnet1 = {
+      address_prefixes = ["10.0.1.0/24"]
+    }
 
-variable "subnet_names" {
-  description = "A list of public subnets inside the vNet."
-  default     = ["subnet1"]
+    subnet1 = {
+      address_prefixes = ["10.0.2.0/24"]
+    }
+  }
 }
 
 variable "tags" {
@@ -33,6 +37,6 @@ variable "tags" {
   type        = map(string)
 
   default = {
-    environment = "dev"
+    ENV = "test"
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "subnets" {
   }
 }
 
+variable "create_nsgs" {
+  type = bool
+  description = "(optional) Should this module create a NSG for each subnet"
+  default = true
+}
+
 variable "tags" {
   description = "The tags to associate with your network and subnets."
   type        = map(string)


### PR DESCRIPTION
Lists are not great for Azure where we have to create a lot of subnets, removing a list element from the beginning of a list subsequently forces all later list elements to be recreated and in the case of terraform and our subnets it tries to destroy and rebuild all our subnets, not ideal. I have changed this to a map where this is not the case.