### PR TITLE
adds missing words and fixes consistency

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "vnet_id" {
 }
 
 output "vnet_name" {
-  description = "The Name of the newly created vNet"
+  description = "The name of the newly created vNet"
   value       = azurerm_virtual_network.vnet.name
 }
 
@@ -19,6 +19,6 @@ output "vnet_address_space" {
 }
 
 output "vnet_subnets" {
-  description = "The ids of subnets created inside the newl vNet"
+  description = "The ids of subnets created inside the newly created vNet"
   value       = azurerm_subnet.subnet.*.id
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:

* adds missing words in output description for `vnet_subnets `
* fixes case consistency in output description for `vnet_name `
