### PR TITLE
Change vnet definition from string to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ resource "azurerm_resource_group" "example" {
 module "network" {
   source              = "Azure/network/azurerm"
   resource_group_name = azurerm_resource_group.example.name
-  address_space       = "10.0.0.0/16"
+  address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
@@ -49,7 +49,7 @@ resource "azurerm_resource_group" "example" {
 module "network" {
   source              = "Azure/network/azurerm"
   resource_group_name = azurerm_resource_group.example.name
-  address_space       = "10.0.0.0/16"
+  address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_virtual_network" "vnet" {
   name                = var.vnet_name
   resource_group_name = data.azurerm_resource_group.network.name
   location            = data.azurerm_resource_group.network.location
-  address_space       = [var.address_space]
+  address_space       = var.address_space
   dns_servers         = var.dns_servers
   tags                = var.tags
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -14,7 +14,7 @@ resource "azurerm_resource_group" "test" {
 module "network" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
-  address_space       = "10.0.0.0/16"
+  address_space       = ["10.0.0.0/16"]
   subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
   subnet_names        = ["subnet1", "subnet2", "subnet3"]
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,8 @@ variable "resource_group_name" {
 
 variable "address_space" {
   description = "The address space that is used by the virtual network."
-  type        = string
-  default     = "10.0.0.0/16"
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
 }
 
 # If no values specified, this defaults to Azure DNS 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

azurerm_virtual_network Terraform module allows defining the address space as a list of CIDR. Current module implementation for the address_space is limited to a single CIDR.

Changes proposed in the pull request:

* Change address_space from string (single CIDR) to list(string) to allow multiple CIDRs to be used when defining a vnet.
