### PR TITLE
tests: destroy resources even if tests fail

### DIFF
--- a/test/terrraform_network_test.go
+++ b/test/terrraform_network_test.go
@@ -12,6 +12,12 @@ func TestTerraformNetwork(t *testing.T) {
 
 	fixtureFolder := "./fixture"
 
+	// At the end of the test, clean up any resources that were created
+	defer test_structure.RunTestStage(t, "teardown", func() {
+		terraformOptions := test_structure.LoadTerraformOptions(t, fixtureFolder)
+		terraform.Destroy(t, terraformOptions)
+	})
+
 	// Deploy the example
 	test_structure.RunTestStage(t, "setup", func() {
 		terraformOptions := configureTerraformOptions(t, fixtureFolder)
@@ -33,11 +39,6 @@ func TestTerraformNetwork(t *testing.T) {
 		}
 	})
 
-	// At the end of the test, clean up any resources that were created
-	test_structure.RunTestStage(t, "teardown", func() {
-		terraformOptions := test_structure.LoadTerraformOptions(t, fixtureFolder)
-		terraform.Destroy(t, terraformOptions)
-	})
 
 }
 


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:

If Go tests fail, the infrastructure is not destroyed, thus having to manually delete it from the Azure Portal. This PR just defers the destroy tests, so whenever the main test function exits, the destroy will be executed.


