### PR TITLE
Change subnet creation to use for_each

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,25 @@ module "network" {
   source              = "Azure/network/azurerm"
   resource_group_name = azurerm_resource_group.example.name
   address_space       = "10.0.0.0/16"
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
-
-  subnet_enforce_private_link_endpoint_network_policies = {
-    "subnet1" : true
-  }
-
-  subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"], 
-    "subnet2" : ["Microsoft.Sql"],
-    "subnet3" : ["Microsoft.Sql"]
+  subnets_list = {
+    subnet-subnet1 = {
+      name                     = "subnet1"
+      address_prefixes         = ["10.0.1.0/24"]
+      enforce_private_link     = true
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet2 = {
+      name                     = "subnet2"
+      address_prefixes         = ["10.0.2.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet3 = {
+      name                     = "subnet3"
+      address_prefixes         = ["10.0.3.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    }
   }
 
   tags = {

--- a/README.md
+++ b/README.md
@@ -23,13 +23,26 @@ module "network" {
   source              = "Azure/network/azurerm"
   resource_group_name = azurerm_resource_group.example.name
   address_spaces      = ["10.0.0.0/16", "10.2.0.0/16"]
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
-  subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"], 
-    "subnet2" : ["Microsoft.Sql"],
-    "subnet3" : ["Microsoft.Sql"]
+  subnets_list = {
+    subnet-subnet1 = {
+      name                     = "subnet1"
+      address_prefixes         = ["10.0.1.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet2 = {
+      name                     = "subnet2"
+      address_prefixes         = ["10.0.2.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet3 = {
+      name                     = "subnet3"
+      address_prefixes         = ["10.0.3.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    }
   }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,6 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name                            = data.azurerm_resource_group.network.name
   address_prefixes                               = each.value.address_prefixes
   virtual_network_name                           = azurerm_virtual_network.vnet.name
-  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link
-  service_endpoints                              = each.value.subnet_service_endpoints
+  enforce_private_link_endpoint_network_policies = lookup(each.value, enforce_private_link, false)
+  service_endpoints                              = lookup(each.value, subnet_service_endpoints, [])
 }

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,6 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name                            = data.azurerm_resource_group.network.name
   address_prefixes                               = each.value.address_prefixes
   virtual_network_name                           = azurerm_virtual_network.vnet.name
-  enforce_private_link_endpoint_network_policies = lookup(each.value, enforce_private_link, false)
-  service_endpoints                              = lookup(each.value, subnet_service_endpoints, [])
+  enforce_private_link_endpoint_network_policies = lookup(each.value, "enforce_private_link", false)
+  service_endpoints                              = lookup(each.value, "subnet_service_endpoints", [])
 }

--- a/main.tf
+++ b/main.tf
@@ -13,11 +13,11 @@ resource "azurerm_virtual_network" "vnet" {
 }
 
 resource "azurerm_subnet" "subnet" {
-  count                                          = length(var.subnet_names)
-  name                                           = var.subnet_names[count.index]
+  for_each                                       = var.subnets_list
+  name                                           = each.value.name
   resource_group_name                            = data.azurerm_resource_group.network.name
-  address_prefixes                               = [var.subnet_prefixes[count.index]]
+  address_prefixes                               = each.value.address_prefixes
   virtual_network_name                           = azurerm_virtual_network.vnet.name
-  enforce_private_link_endpoint_network_policies = lookup(var.subnet_enforce_private_link_endpoint_network_policies, var.subnet_names[count.index], false)
-  service_endpoints                              = lookup(var.subnet_service_endpoints, var.subnet_names[count.index], [])
+  enforce_private_link_endpoint_network_policies = each.value.enforce_private_link
+  service_endpoints                              = each.value.subnet_service_endpoints
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,5 +20,7 @@ output "vnet_address_space" {
 
 output "vnet_subnets" {
   description = "The ids of subnets created inside the newly created vNet"
-  value       = azurerm_subnet.subnet.*.id
+  value = toset([
+    for subnet in azurerm_subnet.subnet : subnet.id
+  ])
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -15,15 +15,26 @@ module "network" {
   source              = "../../"
   resource_group_name = azurerm_resource_group.test.name
   address_spaces      = ["10.0.0.0/16", "10.2.0.0/16"]
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
 
-  subnet_enforce_private_link_endpoint_network_policies = {
-    "subnet1" : true
-  }
-
-  subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"]
+  subnets_list = {
+    subnet-subnet1 = {
+      name                     = "subnet1"
+      address_prefixes         = ["10.0.1.0/24"]
+      enforce_private_link     = true
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet2 = {
+      name                     = "subnet2"
+      address_prefixes         = ["10.0.2.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    },
+    subnet-subnet3 = {
+      name                     = "subnet3"
+      address_prefixes         = ["10.0.3.0/24"]
+      enforce_private_link     = false
+      subnet_service_endpoints = ["Microsoft.Sql"]
+    }
   }
 
   tags = {

--- a/variables.tf
+++ b/variables.tf
@@ -28,16 +28,9 @@ variable "dns_servers" {
   default     = []
 }
 
-variable "subnet_prefixes" {
-  description = "The address prefix to use for the subnet."
-  type        = list(string)
-  default     = ["10.0.1.0/24"]
-}
-
-variable "subnet_names" {
-  description = "A list of public subnets inside the vNet."
-  type        = list(string)
-  default     = ["subnet1"]
+variable "subnets_list" {
+  description = "Subnet list to be created"
+  type        = map(any)
 }
 
 variable "tags" {
@@ -47,16 +40,4 @@ variable "tags" {
   default = {
     environment = "dev"
   }
-}
-
-variable "subnet_enforce_private_link_endpoint_network_policies" {
-  description = "A map with key (string) `subnet name`, value (bool) `true` or `false` to indicate enable or disable network policies for the private link endpoint on the subnet. Default value is false."
-  type        = map(bool)
-  default     = {}
-}
-
-variable "subnet_service_endpoints" {
-  description = "A map with key (string) `subnet name`, value (list(string)) to indicate enabled service endpoints on the subnet. Default value is []."
-  type        = map(list(string))
-  default     = {}
 }


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-network .
$ docker run --rm azure-network /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Changes proposed in the pull request:
My proposal is to change the subnet creation to use `for_each` and not `count` anymore, because using `count` we can't remove a previously created subnet without having to recreate them all.

