### PR TITLE
Add new variable `use_for_each` so we can use `for_each` to create multiple resource instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ module "network" {
 
 ```
 
+## Notice to contributor
+
+Thanks for your contribution! This module was created before Terraform introduce `for_each`, and according to the [document](https://developer.hashicorp.com/terraform/language/meta-arguments/count#when-to-use-for_each-instead-of-count):
+
+>If your instances are almost identical, `count` is appropriate. If some of their arguments need distinct values that can't be directly derived from an integer, it's safer to use `for_each`.
+
+This module contains resources with `count` meta-argument, but if we change `count` to `for_each` directly, it would require heavily manually state move operations with extremely caution, or the users who are maintaining existing infrastructure would face potential breaking change.
+
+This module replicated a new `azurerm_subnet` which used `for_each`, and we provide a new toggle variable named `use_for_each`, this toggle is a switcher between `count` set and `for_each` set. Now user can set `var.use_for_each` to `true` to use `for_each`, and users who're maintaining existing resources could keep this toggle `false` to avoid potential breaking change. If you'd like to make changes to subnet resource, make sure that you've change both `resource` blocks. Thanks for your cooperation.
+
 ## Pre-Commit & Pr-Check & Test
 
 ### Configurations
@@ -190,7 +200,8 @@ No modules.
 
 | Name                                                                                                                                | Type        |
 |-------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [azurerm_subnet.subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)                     | resource    |
+| [azurerm_subnet.subnet_count](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)               | resource    |
+| [azurerm_subnet.subnet_for_each](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet)            | resource    |
 | [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network)     | resource    |
 | [azurerm_resource_group.network](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
@@ -209,6 +220,7 @@ No modules.
 | <a name="input_subnet_prefixes"></a> [subnet\_prefixes](#input\_subnet\_prefixes)                                                                                                                             | The address prefix to use for the subnet.                                                                                                                                                                                                                                                     | `list(string)`                                                                                                                                                                 | <pre>[<br>  "10.0.1.0/24"<br>]</pre>        |    no    |
 | <a name="input_subnet_service_endpoints"></a> [subnet\_service\_endpoints](#input\_subnet\_service\_endpoints)                                                                                                | A map with key (string) `subnet name`, value (list(string)) to indicate enabled service endpoints on the subnet. Default value is [].                                                                                                                                                         | `map(list(string))`                                                                                                                                                            | `{}`                                        |    no    |
 | <a name="input_tags"></a> [tags](#input\_tags)                                                                                                                                                                | The tags to associate with your network and subnets.                                                                                                                                                                                                                                          | `map(string)`                                                                                                                                                                  | <pre>{<br>  "environment": "dev"<br>}</pre> |    no    |
+| <a name="input_use_for_each"></a> [use\_for\_each](#input\_use\_for\_each)                                                                                                                                    | Use `for_each` instead of `count` to create multiple resource instances.                                                                                                                                                                                                                      | `bool`                                                                                                                                                                         | `false`                                     |    no    |
 | <a name="input_vnet_name"></a> [vnet\_name](#input\_vnet\_name)                                                                                                                                               | Name of the vnet to create.                                                                                                                                                                                                                                                                   | `string`                                                                                                                                                                       | `"acctvnet"`                                |    no    |
 
 ## Outputs

--- a/examples/startup/main.tf
+++ b/examples/startup/main.tf
@@ -42,4 +42,5 @@ module "network" {
     environment = "dev"
     costcenter  = "it"
   }
+  use_for_each = true
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  subnet_names_prefixes_map = zipmap(var.subnet_names, var.subnet_prefixes)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,5 +20,5 @@ output "vnet_name" {
 
 output "vnet_subnets" {
   description = "The ids of subnets created inside the newly created vNet"
-  value       = azurerm_subnet.subnet[*].id
+  value       = local.azurerm_subnets[*].id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,13 @@ variable "tags" {
   }
 }
 
+variable "use_for_each" {
+  description = "Use `for_each` instead of `count` to create multiple resource instances."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
 variable "vnet_name" {
   description = "Name of the vnet to create."
   type        = string


### PR DESCRIPTION
## Describe your changes

This module was created before Terraform introduce `for_each`, and according to the [document](https://developer.hashicorp.com/terraform/language/meta-arguments/count#when-to-use-for_each-instead-of-count):

>If your instances are almost identical, `count` is appropriate. If some of their arguments need distinct values that can't be directly derived from an integer, it's safer to use `for_each`.

Since the `azurerm_subnet` resources were created from `var.subnet_names` and these subnets are not identical, we should use `for_each` instead of `count`. But for the users that already maintained existing resources by this module, migrate from `count` to `for_each` requires heavy manually state move operations with extremely caution.

This pull request replicated a new `azurerm_subnet` which used `for_each`, and we provide a new toggle variable named `use_for_each`, this toggle is a switcher between `count` set and `for_each` set. Now user can set `var.use_for_each` to `true` to use `for_each`, and users who're maintaining existing resources could keep this toggle `false` to avoid potential breaking change.

## Issue number

#000

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

