### PR TITLE
Clarify Terraform 1.3 requirement (fixes #88)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ V4.0.0 is a major version upgrade. Extreme caution must be taken during the upgr
 
 Running the `terraform plan` first to inspect the plan is strongly advised.
 
-## Usage in Terraform 0.13
+## Usage
+
 ```hcl
 provider "azurerm" {
   features {}
@@ -55,42 +56,6 @@ module "network" {
 
   depends_on = [azurerm_resource_group.example]
 }
-```
-
-## Usage in Terraform 0.12
-```hcl
-provider "azurerm" {
-  features {}
-}
-
-resource "azurerm_resource_group" "example" {
-  name     = "my-resources"
-  location = "West Europe"
-}
-
-module "network" {
-  source              = "Azure/network/azurerm"
-  resource_group_name = azurerm_resource_group.example.name
-  address_space       = "10.0.0.0/16"
-  subnet_prefixes     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  subnet_names        = ["subnet1", "subnet2", "subnet3"]
-
-  subnet_enforce_private_link_endpoint_network_policies = {
-    "subnet1" : true
-  }
-
-  subnet_service_endpoints = {
-    "subnet1" : ["Microsoft.Sql"],
-    "subnet2" : ["Microsoft.Sql"],
-    "subnet3" : ["Microsoft.Sql"]
-  }
-  use_for_each = true
-  tags = {
-    environment = "dev"
-    costcenter  = "it"
-  }
-}
-
 ```
 
 ## Notice to contributor
@@ -191,7 +156,7 @@ Originally created by [Eugene Chuvyrov](http://github.com/echuvyrov)
 
 | Name                                                                      | Version       |
 |---------------------------------------------------------------------------|---------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2        |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3        |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm)       | >= 3.0, < 4.0 |
 
 ## Providers

--- a/examples/startup/versions.tf
+++ b/examples/startup/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 
   required_providers {
     azurerm = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 
   required_providers {
     azurerm = {


### PR DESCRIPTION
# Describe your changes

This change fixes #88 - it being unclear which version of Terraform is required to use the module - by explicitly qualifying that 1.3 or higher is required.

## Issue number

#88

## Checklist before requesting a review
- [x] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [x] I have executed pre-commit on my machine
- [x] I have passed pr-check on my machine

Thanks for your cooperation!

